### PR TITLE
Add postcss v8 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "string-hash": "^1.1.1"
   },
   "peerDependencies": {
-    "postcss": "^6.0.6 || ^7.0.0"
+    "postcss": "^6.0.6 || ^7.0.0" || ^8.0.0"
   },
   "dependencies": {
     "debug": "^4.3.2",


### PR DESCRIPTION
PostCSS 8 is installed as a dependency of this package, but it is not included as a peer dependency. I add this version of postcss 8 accepted versions to be consistent with the package.json installed version.

This change is required because npm versions 8.6 or higher validate peer dependencies, so a simple `npm ci` that do not have the --force flag set is going to fail breaking our CI's.